### PR TITLE
Add Binance futures trading client and CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,28 @@
-
 cmake_minimum_required(VERSION 3.10)
-project(get_pair_his CXX)
+project(call_api_test CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(PkgConfig REQUIRED)
 find_package(CURL REQUIRED)
-find_package(nlohmann_json REQUIRED)
-find_package(ZLIB REQUIRED)
+find_package(OpenSSL REQUIRED)
 
-pkg_check_modules(LWS REQUIRED libwebsockets)
+include(FetchContent)
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+FetchContent_Declare(nlohmann_json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+)
+FetchContent_MakeAvailable(nlohmann_json)
 
-add_executable(call_api_test main.cpp call_api_demo.cpp)
+add_executable(call_api_test
+    main.cpp
+    call_api_demo.cpp
+    binance_client.cpp
+)
 
-target_include_directories(get_pair_his PRIVATE ${LWS_INCLUDE_DIRS})
-target_compile_options(get_pair_his PRIVATE ${LWS_CFLAGS_OTHER})
-target_link_libraries(get_pair_his PRIVATE
-    ${LWS_LIBRARIES}
+target_link_libraries(call_api_test PRIVATE
     CURL::libcurl
+    OpenSSL::SSL
+    OpenSSL::Crypto
     nlohmann_json::nlohmann_json
-    ZLIB::ZLIB
 )

--- a/binance_client.cpp
+++ b/binance_client.cpp
@@ -1,0 +1,438 @@
+#include "binance_client.hpp"
+
+#include <curl/curl.h>
+#include <openssl/hmac.h>
+
+#include <chrono>
+#include <cmath>
+#include <cctype>
+#include <iomanip>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using json = nlohmann::json;
+
+namespace {
+size_t write_callback(void* contents, size_t size, size_t nmemb, void* userp) {
+    const size_t totalSize = size * nmemb;
+    auto* buffer = static_cast<std::string*>(userp);
+    buffer->append(static_cast<char*>(contents), totalSize);
+    return totalSize;
+}
+
+long long current_timestamp_ms() {
+    using namespace std::chrono;
+    return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+}
+
+std::string uppercase(std::string value) {
+    for (auto& c : value) {
+        c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    }
+    return value;
+}
+
+std::string pick_position_side(const json& position) {
+    if (position.contains("positionSide")) {
+        return position.at("positionSide").get<std::string>();
+    }
+    return "BOTH";
+}
+}  // namespace
+
+BinanceFuturesClient::BinanceFuturesClient(std::string apiKey,
+                                           std::string secretKey,
+                                           bool useTestnet,
+                                           long recvWindow)
+    : apiKey_(std::move(apiKey)),
+      secretKey_(std::move(secretKey)),
+      baseUrl_(useTestnet ? "https://testnet.binancefuture.com" : "https://fapi.binance.com"),
+      recvWindow_(recvWindow) {
+}
+
+std::string BinanceFuturesClient::buildQuery(void* curlHandle, const Params& params) const {
+    std::string query;
+    CURL* curl = static_cast<CURL*>(curlHandle);
+    for (const auto& [key, value] : params) {
+        if (value.empty()) {
+            continue;
+        }
+        char* encoded = curl_easy_escape(curl, value.c_str(), static_cast<int>(value.size()));
+        if (!encoded) {
+            throw std::runtime_error("Failed to URL encode parameter");
+        }
+        if (!query.empty()) {
+            query.push_back('&');
+        }
+        query += key;
+        query.push_back('=');
+        query += encoded;
+        curl_free(encoded);
+    }
+    return query;
+}
+
+std::string BinanceFuturesClient::sign(const std::string& payload) const {
+    unsigned int len = 0;
+    const unsigned char* result = HMAC(EVP_sha256(), secretKey_.data(), static_cast<int>(secretKey_.size()),
+                                       reinterpret_cast<const unsigned char*>(payload.data()), payload.size(), nullptr, &len);
+    if (!result) {
+        throw std::runtime_error("Failed to sign payload");
+    }
+
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0');
+    for (unsigned int i = 0; i < len; ++i) {
+        oss << std::setw(2) << static_cast<int>(result[i]);
+    }
+    return oss.str();
+}
+
+json BinanceFuturesClient::performRequest(const std::string& method,
+                                          const std::string& path,
+                                          const Params& params,
+                                          bool isSigned) {
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        throw std::runtime_error("Failed to initialise curl");
+    }
+
+    std::string url = baseUrl_ + path;
+    std::string body;
+
+    std::string query = buildQuery(curl, params);
+
+    std::string signedQuery = query;
+    if (isSigned) {
+        if (apiKey_.empty() || secretKey_.empty()) {
+            curl_easy_cleanup(curl);
+            throw std::runtime_error("API key and secret are required for private endpoints");
+        }
+        if (!signedQuery.empty()) {
+            signedQuery.push_back('&');
+        }
+        signedQuery += "timestamp=" + std::to_string(current_timestamp_ms());
+        if (recvWindow_ > 0) {
+            signedQuery += "&recvWindow=" + std::to_string(recvWindow_);
+        }
+        const std::string signature = sign(signedQuery);
+        signedQuery += "&signature=" + signature;
+    }
+
+    if (method == "GET" || method == "DELETE") {
+        if (!signedQuery.empty()) {
+            url += "?";
+            url += signedQuery;
+        }
+    } else {
+        body = isSigned ? signedQuery : query;
+    }
+
+    std::string response;
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+
+    struct curl_slist* headers = nullptr;
+    if (isSigned && !apiKey_.empty()) {
+        std::string header = "X-MBX-APIKEY: " + apiKey_;
+        headers = curl_slist_append(headers, header.c_str());
+    }
+
+    if (method == "POST") {
+        curl_easy_setopt(curl, CURLOPT_POST, 1L);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+    } else if (method == "DELETE") {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method.c_str());
+    }
+
+    if (headers) {
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    }
+
+    CURLcode res = curl_easy_perform(curl);
+
+    long httpStatus = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpStatus);
+
+    if (headers) {
+        curl_slist_free_all(headers);
+    }
+
+    curl_easy_cleanup(curl);
+
+    if (res != CURLE_OK) {
+        std::ostringstream oss;
+        oss << "curl_easy_perform() failed: " << curl_easy_strerror(res);
+        throw std::runtime_error(oss.str());
+    }
+
+    if (httpStatus >= 400) {
+        std::ostringstream oss;
+        oss << "HTTP error " << httpStatus << ": " << response;
+        throw std::runtime_error(oss.str());
+    }
+
+    if (response.empty()) {
+        return json::object();
+    }
+
+    return json::parse(response);
+}
+
+std::string BinanceFuturesClient::toString(Side side) {
+    return side == Side::BUY ? "BUY" : "SELL";
+}
+
+std::string BinanceFuturesClient::toString(OrderType type) {
+    switch (type) {
+        case OrderType::MARKET:
+            return "MARKET";
+        case OrderType::LIMIT:
+            return "LIMIT";
+        case OrderType::STOP_MARKET:
+            return "STOP_MARKET";
+        case OrderType::TAKE_PROFIT_MARKET:
+            return "TAKE_PROFIT_MARKET";
+        default:
+            throw std::runtime_error("Unsupported order type");
+    }
+}
+
+std::string BinanceFuturesClient::toString(TimeInForce tif) {
+    switch (tif) {
+        case TimeInForce::GTC:
+            return "GTC";
+        case TimeInForce::IOC:
+            return "IOC";
+        case TimeInForce::FOK:
+            return "FOK";
+        case TimeInForce::GTX:
+            return "GTX";
+        default:
+            throw std::runtime_error("Unsupported time-in-force");
+    }
+}
+
+std::string BinanceFuturesClient::formatDouble(double value) {
+    std::ostringstream oss;
+    oss.setf(std::ios::fixed);
+    oss << std::setprecision(8) << value;
+    std::string str = oss.str();
+    auto pos = str.find_last_not_of('0');
+    if (pos != std::string::npos) {
+        if (str[pos] == '.') {
+            str.erase(pos);
+        } else {
+            str.erase(pos + 1);
+        }
+    }
+    if (str.empty()) {
+        return "0";
+    }
+    return str;
+}
+
+json BinanceFuturesClient::getContinuousKlines(const std::string& pair,
+                                               const std::string& interval,
+                                               int limit,
+                                               const std::string& contractType) {
+    Params params{
+        {"pair", pair},
+        {"contractType", contractType},
+        {"interval", interval},
+        {"limit", std::to_string(limit)}
+    };
+    return performRequest("GET", "/fapi/v1/continuousKlines", params, false);
+}
+
+json BinanceFuturesClient::setLeverage(const std::string& symbol, int leverage) {
+    Params params{
+        {"symbol", uppercase(symbol)},
+        {"leverage", std::to_string(leverage)}
+    };
+    return performRequest("POST", "/fapi/v1/leverage", params, true);
+}
+
+json BinanceFuturesClient::placeOrder(const OrderRequest& request) {
+    Params params{
+        {"symbol", uppercase(request.symbol)},
+        {"side", toString(request.side)},
+        {"type", toString(request.type)}
+    };
+
+    if (request.quantity) {
+        params.emplace_back("quantity", formatDouble(*request.quantity));
+    }
+    if (request.quoteOrderQty) {
+        params.emplace_back("quoteOrderQty", formatDouble(*request.quoteOrderQty));
+    }
+    if (request.price) {
+        params.emplace_back("price", formatDouble(*request.price));
+    }
+    if (request.timeInForce) {
+        params.emplace_back("timeInForce", toString(*request.timeInForce));
+    }
+    if (request.reduceOnly) {
+        params.emplace_back("reduceOnly", *request.reduceOnly ? "true" : "false");
+    }
+    if (request.positionSide) {
+        params.emplace_back("positionSide", uppercase(*request.positionSide));
+    }
+    if (request.clientOrderId) {
+        params.emplace_back("newClientOrderId", *request.clientOrderId);
+    }
+    if (request.stopPrice) {
+        params.emplace_back("stopPrice", formatDouble(*request.stopPrice));
+    }
+
+    if (!request.quantity && !request.quoteOrderQty) {
+        throw std::runtime_error("Either quantity or quoteOrderQty must be provided");
+    }
+
+    json result;
+    json entry = performRequest("POST", "/fapi/v1/order", params, true);
+    result["entry"] = entry;
+
+    const auto executedQty = entry.value("executedQty", entry.value("origQty", std::string{}));
+
+    auto createOcoOrder = [&](const std::optional<double>& priceValue, const std::string& orderType) -> std::optional<json> {
+        if (!priceValue) {
+            return std::nullopt;
+        }
+        Params extra{
+            {"symbol", uppercase(request.symbol)},
+            {"side", request.side == Side::BUY ? "SELL" : "BUY"},
+            {"type", orderType},
+            {"stopPrice", formatDouble(*priceValue)},
+            {"reduceOnly", "true"},
+            {"workingType", "MARK_PRICE"}
+        };
+
+        if (!executedQty.empty()) {
+            extra.emplace_back("quantity", executedQty);
+        } else if (request.quantity) {
+            extra.emplace_back("quantity", formatDouble(*request.quantity));
+        } else {
+            throw std::runtime_error("Unable to determine quantity for protective order");
+        }
+
+        if (request.positionSide) {
+            extra.emplace_back("positionSide", uppercase(*request.positionSide));
+        }
+
+        return performRequest("POST", "/fapi/v1/order", extra, true);
+    };
+
+    if (auto stopLoss = createOcoOrder(request.stopLossPrice, "STOP_MARKET")) {
+        result["stopLoss"] = *stopLoss;
+    }
+    if (auto takeProfit = createOcoOrder(request.takeProfitPrice, "TAKE_PROFIT_MARKET")) {
+        result["takeProfit"] = *takeProfit;
+    }
+
+    return result;
+}
+
+json BinanceFuturesClient::getOpenOrders(const std::string& symbol) {
+    Params params;
+    if (!symbol.empty()) {
+        params.emplace_back("symbol", uppercase(symbol));
+    }
+    return performRequest("GET", "/fapi/v1/openOrders", params, true);
+}
+
+json BinanceFuturesClient::getAllOrders(const std::string& symbol, int limit) {
+    Params params{
+        {"symbol", uppercase(symbol)},
+        {"limit", std::to_string(limit)}
+    };
+    return performRequest("GET", "/fapi/v1/allOrders", params, true);
+}
+
+json BinanceFuturesClient::getAccountInfo() {
+    Params params;
+    return performRequest("GET", "/fapi/v2/account", params, true);
+}
+
+json BinanceFuturesClient::getPositionRisk(const std::string& symbol) {
+    Params params;
+    if (!symbol.empty()) {
+        params.emplace_back("symbol", uppercase(symbol));
+    }
+    return performRequest("GET", "/fapi/v2/positionRisk", params, true);
+}
+
+json BinanceFuturesClient::getFundingRate(const std::string& symbol, int limit) {
+    Params params{
+        {"symbol", uppercase(symbol)},
+        {"limit", std::to_string(limit)}
+    };
+    return performRequest("GET", "/fapi/v1/fundingRate", params, false);
+}
+
+json BinanceFuturesClient::getFundingFeeHistory(const std::string& symbol, int limit) {
+    Params params{
+        {"symbol", uppercase(symbol)},
+        {"incomeType", "FUNDING_FEE"},
+        {"limit", std::to_string(limit)}
+    };
+    return performRequest("GET", "/fapi/v1/income", params, true);
+}
+
+json BinanceFuturesClient::closePosition(const std::string& symbol) {
+    json positions = getPositionRisk(symbol);
+    if (!positions.is_array()) {
+        throw std::runtime_error("Unexpected response for position risk");
+    }
+
+    std::string normalisedSymbol = uppercase(symbol);
+    std::string closeSide;
+    std::string quantity;
+    std::optional<std::string> positionSide;
+
+    for (const auto& pos : positions) {
+        if (!pos.contains("symbol")) {
+            continue;
+        }
+        if (uppercase(pos.at("symbol").get<std::string>()) != normalisedSymbol) {
+            continue;
+        }
+        const double positionAmt = std::stod(pos.value("positionAmt", "0"));
+        if (std::fabs(positionAmt) < 1e-12) {
+            continue;
+        }
+        closeSide = positionAmt > 0 ? "SELL" : "BUY";
+        quantity = formatDouble(std::fabs(positionAmt));
+        const std::string sideValue = pick_position_side(pos);
+        if (sideValue != "BOTH") {
+            positionSide = sideValue;
+        }
+        break;
+    }
+
+    if (closeSide.empty() || quantity.empty()) {
+        return json{{"symbol", normalisedSymbol}, {"message", "No open position"}};
+    }
+
+    Params params{
+        {"symbol", normalisedSymbol},
+        {"side", closeSide},
+        {"type", "MARKET"},
+        {"quantity", quantity},
+        {"reduceOnly", "true"}
+    };
+
+    if (positionSide) {
+        params.emplace_back("positionSide", uppercase(*positionSide));
+    }
+
+    json response = performRequest("POST", "/fapi/v1/order", params, true);
+    return json{{"symbol", normalisedSymbol}, {"close", response}};
+}

--- a/binance_client.hpp
+++ b/binance_client.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+class BinanceFuturesClient {
+public:
+    enum class Side { BUY, SELL };
+    enum class OrderType {
+        MARKET,
+        LIMIT,
+        STOP_MARKET,
+        TAKE_PROFIT_MARKET
+    };
+    enum class TimeInForce {
+        GTC,
+        IOC,
+        FOK,
+        GTX
+    };
+
+    struct OrderRequest {
+        std::string symbol;
+        Side side = Side::BUY;
+        OrderType type = OrderType::MARKET;
+        std::optional<double> quantity;
+        std::optional<double> quoteOrderQty;
+        std::optional<double> price;
+        std::optional<TimeInForce> timeInForce;
+        std::optional<bool> reduceOnly;
+        std::optional<std::string> positionSide;
+        std::optional<std::string> clientOrderId;
+        std::optional<double> stopPrice;
+        std::optional<double> takeProfitPrice;
+        std::optional<double> stopLossPrice;
+    };
+
+    BinanceFuturesClient(std::string apiKey, std::string secretKey, bool useTestnet = true, long recvWindow = 5000);
+
+    nlohmann::json getContinuousKlines(const std::string& pair,
+                                       const std::string& interval,
+                                       int limit = 500,
+                                       const std::string& contractType = "PERPETUAL");
+
+    nlohmann::json setLeverage(const std::string& symbol, int leverage);
+
+    nlohmann::json placeOrder(const OrderRequest& request);
+
+    nlohmann::json getOpenOrders(const std::string& symbol = "");
+
+    nlohmann::json getAllOrders(const std::string& symbol, int limit = 500);
+
+    nlohmann::json getAccountInfo();
+
+    nlohmann::json getPositionRisk(const std::string& symbol = "");
+
+    nlohmann::json getFundingRate(const std::string& symbol, int limit = 1);
+
+    nlohmann::json getFundingFeeHistory(const std::string& symbol, int limit = 10);
+
+    nlohmann::json closePosition(const std::string& symbol);
+
+private:
+    using Params = std::vector<std::pair<std::string, std::string>>;
+
+    nlohmann::json performRequest(const std::string& method,
+                                  const std::string& path,
+                                  const Params& params,
+                                  bool isSigned);
+
+    std::string buildQuery(void* curlHandle, const Params& params) const;
+
+    std::string sign(const std::string& payload) const;
+
+    static std::string toString(Side side);
+    static std::string toString(OrderType type);
+    static std::string toString(TimeInForce tif);
+
+    static std::string formatDouble(double value);
+
+    std::string apiKey_;
+    std::string secretKey_;
+    std::string baseUrl_;
+    long recvWindow_;
+};

--- a/call_api_demo.cpp
+++ b/call_api_demo.cpp
@@ -1,57 +1,336 @@
-#include <filesystem>
+#include "binance_client.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <exception>
 #include <iostream>
-#include <fstream>
+#include <map>
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <chrono>
-#include <thread>
-#include <ctime>
-#include <curl/curl.h>
-#include <nlohmann/json.hpp>
 
-namespace fs = std::filesystem;
 using json = nlohmann::json;
 
-size_t write_callback(void* contents, size_t size, size_t nmemb, void* userp) {
-    ((std::string*)userp)->append((char*)contents, size * nmemb);
-    return size * nmemb;
+namespace {
+
+std::string to_upper(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return value;
 }
 
-std::string fetch_binance(const std::string& url) {
-    CURL* curl;
-    CURLcode res;
-    std::string readBuffer;
+bool parse_bool(const std::string& value) {
+    const std::string upper = to_upper(value);
+    return upper == "1" || upper == "TRUE" || upper == "YES" || upper == "ON";
+}
 
-    curl = curl_easy_init();
-    if (curl) {
-        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
-        res = curl_easy_perform(curl);
-        if (res != CURLE_OK) {
-            std::cerr << "curl_easy_perform() failed: " << curl_easy_strerror(res) << std::endl;
+void print_usage() {
+    std::cout << "Usage:\n"
+              << "  call_api_test klines <PAIR> <INTERVAL> [LIMIT] [CONTRACT_TYPE]\n"
+              << "  call_api_test set-leverage <SYMBOL> <LEVERAGE>\n"
+              << "  call_api_test place-order <SYMBOL> <SIDE> <TYPE> [options]\n"
+              << "      Options: --quantity <qty> --quoteQty <qty> --price <price> --timeInForce <GTC|IOC|FOK|GTX>\n"
+              << "               --reduceOnly [true|false] --positionSide <BOTH|LONG|SHORT> --clientOrderId <id>\n"
+              << "               --stopPrice <price> --stopLoss <price> --takeProfit <price>\n"
+              << "  call_api_test open-orders [SYMBOL]\n"
+              << "  call_api_test all-orders <SYMBOL> [LIMIT]\n"
+              << "  call_api_test account\n"
+              << "  call_api_test position-risk [SYMBOL]\n"
+              << "  call_api_test funding-rate <SYMBOL> [LIMIT]\n"
+              << "  call_api_test funding-fee <SYMBOL> [LIMIT]\n"
+              << "  call_api_test close-position <SYMBOL>\n"
+              << "  call_api_test status <SYMBOL>\n";
+}
+
+BinanceFuturesClient::Side parse_side(const std::string& value) {
+    const std::string upper = to_upper(value);
+    if (upper == "BUY") {
+        return BinanceFuturesClient::Side::BUY;
+    }
+    if (upper == "SELL") {
+        return BinanceFuturesClient::Side::SELL;
+    }
+    throw std::runtime_error("Unsupported side: " + value);
+}
+
+BinanceFuturesClient::OrderType parse_order_type(const std::string& value) {
+    const std::string upper = to_upper(value);
+    if (upper == "MARKET") {
+        return BinanceFuturesClient::OrderType::MARKET;
+    }
+    if (upper == "LIMIT") {
+        return BinanceFuturesClient::OrderType::LIMIT;
+    }
+    if (upper == "STOP_MARKET") {
+        return BinanceFuturesClient::OrderType::STOP_MARKET;
+    }
+    if (upper == "TAKE_PROFIT_MARKET") {
+        return BinanceFuturesClient::OrderType::TAKE_PROFIT_MARKET;
+    }
+    throw std::runtime_error("Unsupported order type: " + value);
+}
+
+BinanceFuturesClient::TimeInForce parse_time_in_force(const std::string& value) {
+    const std::string upper = to_upper(value);
+    if (upper == "GTC") {
+        return BinanceFuturesClient::TimeInForce::GTC;
+    }
+    if (upper == "IOC") {
+        return BinanceFuturesClient::TimeInForce::IOC;
+    }
+    if (upper == "FOK") {
+        return BinanceFuturesClient::TimeInForce::FOK;
+    }
+    if (upper == "GTX") {
+        return BinanceFuturesClient::TimeInForce::GTX;
+    }
+    throw std::runtime_error("Unsupported time-in-force: " + value);
+}
+
+std::map<std::string, std::string> parse_options(int startIndex, int argc, char* argv[]) {
+    std::map<std::string, std::string> options;
+    for (int i = startIndex; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg.rfind("--", 0) != 0) {
+            throw std::runtime_error("Unexpected argument: " + arg);
         }
-        curl_easy_cleanup(curl);
+        std::string key = arg.substr(2);
+        std::string value = "true";
+        if (i + 1 < argc) {
+            std::string next = argv[i + 1];
+            if (next.rfind("--", 0) != 0) {
+                value = next;
+                ++i;
+            }
+        }
+        options[key] = value;
     }
-    return readBuffer;
+    return options;
 }
 
-int call_api_demo() {
-    std::string symbol = "ETHUSDT";
-    const std::string base_url = "https://fapi.binance.com/fapi/v1/continuousKlines?pair=" + symbol +
-        "&contractType=PERPETUAL&interval=1m&limit=1500";
-    std::string data = fetch_binance(url);
-    if (data.empty()) return 1;
-    json j;
+void print_json(const json& value) {
+    std::cout << value.dump(2) << std::endl;
+}
+
+bool read_use_testnet_from_env() {
+    const char* env = std::getenv("BINANCE_USE_TESTNET");
+    if (!env) {
+        return true;
+    }
+    const std::string value = to_upper(env);
+    return !(value == "0" || value == "FALSE" || value == "NO" || value == "OFF");
+}
+
+BinanceFuturesClient create_public_client() {
+    return BinanceFuturesClient("", "", read_use_testnet_from_env());
+}
+
+BinanceFuturesClient create_private_client(const char* apiKey, const char* apiSecret) {
+    return BinanceFuturesClient(apiKey ? apiKey : "", apiSecret ? apiSecret : "", read_use_testnet_from_env());
+}
+
+}  // namespace
+
+int call_api_demo(int argc, char* argv[]) {
     try {
-        j = json::parse(data);
+        if (argc == 1) {
+            print_usage();
+            std::cout << "\nFetching latest ETHUSDT 1m perpetual contract candles..." << std::endl;
+            BinanceFuturesClient publicClient = create_public_client();
+            auto candles = publicClient.getContinuousKlines("ETHUSDT", "1m", 5);
+            print_json(candles);
+
+            const char* apiKey = std::getenv("BINANCE_API_KEY");
+            const char* apiSecret = std::getenv("BINANCE_API_SECRET");
+            if (apiKey && apiSecret) {
+                BinanceFuturesClient client = create_private_client(apiKey, apiSecret);
+                json summary;
+                summary["account"] = client.getAccountInfo();
+                summary["positions"] = client.getPositionRisk("ETHUSDT");
+                summary["funding"] = client.getFundingRate("ETHUSDT", 1);
+                print_json(summary);
+            } else {
+                std::cout << "\nSet BINANCE_API_KEY and BINANCE_API_SECRET environment variables to enable trading commands." << std::endl;
+            }
+            return 0;
+        }
+
+        const std::string command = argv[1];
+
+        if (command == "klines") {
+            if (argc < 4) {
+                throw std::runtime_error("klines requires at least <PAIR> and <INTERVAL>");
+            }
+            const std::string pair = argv[2];
+            const std::string interval = argv[3];
+            int limit = 500;
+            if (argc >= 5) {
+                limit = std::stoi(argv[4]);
+            }
+            std::string contractType = "PERPETUAL";
+            if (argc >= 6) {
+                contractType = argv[5];
+            }
+            BinanceFuturesClient publicClient = create_public_client();
+            auto data = publicClient.getContinuousKlines(pair, interval, limit, contractType);
+            print_json(data);
+            return 0;
+        }
+
+        const char* apiKey = std::getenv("BINANCE_API_KEY");
+        const char* apiSecret = std::getenv("BINANCE_API_SECRET");
+        if (!apiKey || !apiSecret) {
+            throw std::runtime_error("BINANCE_API_KEY and BINANCE_API_SECRET must be set for this command");
+        }
+
+        BinanceFuturesClient client = create_private_client(apiKey, apiSecret);
+
+        if (command == "set-leverage") {
+            if (argc < 4) {
+                throw std::runtime_error("set-leverage requires <SYMBOL> and <LEVERAGE>");
+            }
+            const std::string symbol = argv[2];
+            int leverage = std::stoi(argv[3]);
+            auto response = client.setLeverage(symbol, leverage);
+            print_json(response);
+            return 0;
+        }
+        if (command == "place-order") {
+            if (argc < 5) {
+                throw std::runtime_error("place-order requires <SYMBOL> <SIDE> <TYPE>");
+            }
+            BinanceFuturesClient::OrderRequest request;
+            request.symbol = argv[2];
+            request.side = parse_side(argv[3]);
+            request.type = parse_order_type(argv[4]);
+
+            auto options = parse_options(5, argc, argv);
+            if (auto it = options.find("quantity"); it != options.end()) {
+                request.quantity = std::stod(it->second);
+            }
+            if (auto it = options.find("quoteQty"); it != options.end()) {
+                request.quoteOrderQty = std::stod(it->second);
+            }
+            if (auto it = options.find("price"); it != options.end()) {
+                request.price = std::stod(it->second);
+            }
+            if (auto it = options.find("timeInForce"); it != options.end()) {
+                request.timeInForce = parse_time_in_force(it->second);
+            }
+            if (auto it = options.find("reduceOnly"); it != options.end()) {
+                request.reduceOnly = parse_bool(it->second);
+            }
+            if (auto it = options.find("positionSide"); it != options.end()) {
+                request.positionSide = it->second;
+            }
+            if (auto it = options.find("clientOrderId"); it != options.end()) {
+                request.clientOrderId = it->second;
+            }
+            if (auto it = options.find("stopPrice"); it != options.end()) {
+                request.stopPrice = std::stod(it->second);
+            }
+            if (auto it = options.find("stopLoss"); it != options.end()) {
+                request.stopLossPrice = std::stod(it->second);
+            }
+            if (auto it = options.find("takeProfit"); it != options.end()) {
+                request.takeProfitPrice = std::stod(it->second);
+            }
+
+            auto response = client.placeOrder(request);
+            print_json(response);
+            return 0;
+        }
+        if (command == "open-orders") {
+            std::string symbol;
+            if (argc >= 3) {
+                symbol = argv[2];
+            }
+            auto response = client.getOpenOrders(symbol);
+            print_json(response);
+            return 0;
+        }
+        if (command == "all-orders") {
+            if (argc < 3) {
+                throw std::runtime_error("all-orders requires <SYMBOL>");
+            }
+            const std::string symbol = argv[2];
+            int limit = 500;
+            if (argc >= 4) {
+                limit = std::stoi(argv[3]);
+            }
+            auto response = client.getAllOrders(symbol, limit);
+            print_json(response);
+            return 0;
+        }
+        if (command == "account") {
+            auto response = client.getAccountInfo();
+            print_json(response);
+            return 0;
+        }
+        if (command == "position-risk") {
+            std::string symbol;
+            if (argc >= 3) {
+                symbol = argv[2];
+            }
+            auto response = client.getPositionRisk(symbol);
+            print_json(response);
+            return 0;
+        }
+        if (command == "funding-rate") {
+            if (argc < 3) {
+                throw std::runtime_error("funding-rate requires <SYMBOL>");
+            }
+            const std::string symbol = argv[2];
+            int limit = 1;
+            if (argc >= 4) {
+                limit = std::stoi(argv[3]);
+            }
+            auto response = client.getFundingRate(symbol, limit);
+            print_json(response);
+            return 0;
+        }
+        if (command == "funding-fee") {
+            if (argc < 3) {
+                throw std::runtime_error("funding-fee requires <SYMBOL>");
+            }
+            const std::string symbol = argv[2];
+            int limit = 10;
+            if (argc >= 4) {
+                limit = std::stoi(argv[3]);
+            }
+            auto response = client.getFundingFeeHistory(symbol, limit);
+            print_json(response);
+            return 0;
+        }
+        if (command == "close-position") {
+            if (argc < 3) {
+                throw std::runtime_error("close-position requires <SYMBOL>");
+            }
+            const std::string symbol = argv[2];
+            auto response = client.closePosition(symbol);
+            print_json(response);
+            return 0;
+        }
+        if (command == "status") {
+            if (argc < 3) {
+                throw std::runtime_error("status requires <SYMBOL>");
+            }
+            const std::string symbol = argv[2];
+            json result;
+            result["symbol"] = symbol;
+            result["positionRisk"] = client.getPositionRisk(symbol);
+            result["openOrders"] = client.getOpenOrders(symbol);
+            result["fundingRate"] = client.getFundingRate(symbol, 1);
+            result["fundingFee"] = client.getFundingFeeHistory(symbol, 10);
+            print_json(result);
+            return 0;
+        }
+
+        throw std::runtime_error("Unknown command: " + command);
     }
-    catch (...) {
-        std::cerr << "JSON parse error" << std::endl;
-        throw std::runtime_error("api JSON parse fatal error");
+    catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1;
     }
-    std::cout << data << std::endl;
-    return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,14 +1,12 @@
 #include <iostream>
 #include <string>
 #include <stdexcept>
-#include <curl/curl.h>
 
-int call_api_demo();
+int call_api_demo(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
     try {
-        call_api_demo();
-        return 0;
+        return call_api_demo(argc, argv);
     }
     catch (const std::exception& e) {
         std::cerr << "Exception: " << e.what() << std::endl;
@@ -18,6 +16,4 @@ int main(int argc, char* argv[]) {
         std::cerr << "Unknown exception" << std::endl;
         return -100;
     }
-
-    return 0;
 }


### PR DESCRIPTION
## Summary
- add a BinanceFuturesClient wrapper that handles signing, leverage settings, orders, funding data, and position management
- expose the new features through a CLI in `call_api_demo.cpp` so orders, funding, PnL, and closures can be managed from the terminal
- refresh the CMake project to fetch nlohmann_json and link the required CURL and OpenSSL dependencies

## Testing
- cmake -S call_api_test -B call_api_test/build
- cmake --build call_api_test/build
- call_api_test/build/call_api_test


------
https://chatgpt.com/codex/tasks/task_e_68d35cb4b884832b99056f44266f86cf